### PR TITLE
fix missing test dep

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -15,4 +15,5 @@ on test => sub {
    requires 'Archive::Extract';
    requires 'Test::More' => '0.88';
    requires 'Test::utf8' => '0.02';
+   requires 'Test::Pod' => '1.51';
 }


### PR DESCRIPTION
`dzil test` was failing on `t/author-pod-syntax.t` (I've used `dzil authordeps --missing |cpanm` & `dzil listdeps |cpanm` to install deps for local development).