### PR TITLE
fix GH #9

### DIFF
--- a/lib/Cogit/Loose.pm
+++ b/lib/Cogit/Loose.pm
@@ -50,8 +50,8 @@ sub all_sha1s {
     );
     return Data::Stream::Bulk::Filter->new(
         filter => sub {
-            [   map { m{([a-z0-9]{2})[/\\]([a-z0-9]{38})}; $1 . $2 }
-                    grep {m{[/\\][a-z0-9]{2}[/\\]}} @$_
+            [   map { m{[/\\]([a-z0-9]{2})[/\\]([a-z0-9]{38})} ? $1 . $2 : () }
+                    @$_
             ];
         },
         stream => $files,


### PR DESCRIPTION
The fix follows @book's suggestion to silently ignore files that do not match filter regex.

I've checked that the warning vanishes for a local repo, where I'd just `touch`'ed some empty file based on filename pattern from @book's issue (#9).

However, I have hard time thinking of an example workflow so that such file would be naturally created by `git` (that'd be a neat way to test it, right?;).